### PR TITLE
Calculator Deployment

### DIFF
--- a/locus-calculator/goerli.yaml
+++ b/locus-calculator/goerli.yaml
@@ -1,0 +1,3 @@
+dapp:
+  image: docker.io/marcussouza90/marcus-repo:calculator
+  contractAddress: "0xE0041F2aFeA88004E0C8AA0cA6060DF47303Ee60"


### PR DESCRIPTION
## Brief
The first Atempt to use the Cartesi infrastructure for Calculator DApp.

## Main activities
Following the [Cartesi Instructions](https://github.com/cartesi/rollups-deployment)
