### PR TITLE
feat: add aetheras-dinder dapp for arbitrum-goerli, optimism-goerli, goerli, and gnosis-chiado

### DIFF
--- a/aetheras-dinder/arbitrum-goerli.yml
+++ b/aetheras-dinder/arbitrum-goerli.yml
@@ -1,0 +1,3 @@
+dapp:
+  image: gcr.io/aetheras-io/dinder-cartesi:v0.2.1
+  contractAddress: "0x5414c4DeAF663578ff2BF5f5079a5e56a545A7a6"

--- a/aetheras-dinder/chiado.yml
+++ b/aetheras-dinder/chiado.yml
@@ -1,0 +1,3 @@
+dapp:
+  image: gcr.io/aetheras-io/dinder-cartesi:v0.2.1
+  contractAddress: "0xbB89138717A377b99bF4F54Afa3f4ABFd0b74443"

--- a/aetheras-dinder/goerli.yml
+++ b/aetheras-dinder/goerli.yml
@@ -1,0 +1,3 @@
+dapp:
+  image: gcr.io/aetheras-io/dinder-cartesi:v0.2.1
+  contractAddress: "0x2232dD56B7dE3A52Cb61dA9c08872384F3fd2568"

--- a/aetheras-dinder/optimism-goerli.yml
+++ b/aetheras-dinder/optimism-goerli.yml
@@ -1,0 +1,3 @@
+dapp:
+  image: gcr.io/aetheras-io/dinder-cartesi:v0.2.1
+  contractAddress: "0x69f54D30aC5b8aDdbE01F991210F55166BF0960d"


### PR DESCRIPTION
# Brief
Adding the dinder-cartesi DApp to be accepted in the infrastructure.

# Main Activities
Added .yaml file as requested in the documentation.